### PR TITLE
Use stable sort to ensure already-sorted input stays sorted.

### DIFF
--- a/dictfmt.c
+++ b/dictfmt.c
@@ -162,9 +162,9 @@ static void fmt_openindex( const char *filename )
    char buffer [1024];
 
    if (bit8_mode || utf8_mode || allchars_mode)
-      snprintf( buffer, sizeof (buffer), "sort -t '\t' -k 1,1 " );
+      snprintf( buffer, sizeof (buffer), "sort -st '\t' -k 1,1 " );
    else
-      snprintf( buffer, sizeof (buffer), "sort -t '\t' -df -k 1,1 " );
+      snprintf( buffer, sizeof (buffer), "sort -st '\t' -df -k 1,1 " );
 
    if (filename){
       strlcat (buffer, "> ", sizeof (buffer));


### PR DESCRIPTION
I use dictd with [oed2dict](https://njw.name/oed2dict/) and the OED. Since the input to dictfmt there is already sorted, using a non-stable sort will make single definitions with multiple entries (which will show up in dict output as multiple single entries) be displayed in a seemingly random order. This patch aims to fix that issue.

**Note**: The -s flag is not defined by POSIX, but seems to be widely accepted and used. It's found in GNU's coreutils and all BSD sort implementations I've found.