### PR TITLE
Use XDG_CONFIG_HOME by default for coloritrc

### DIFF
--- a/colorit/colorit.1.in
+++ b/colorit/colorit.1.in
@@ -46,6 +46,8 @@ Shows help information.
 .TP
 .BI \-c " file\fR or "  \-\-config " file"
 Specify configuration file.  The default is
+.I $XDG_CONFIG_HOME/coloritrc
+or
 .I ~/.coloritrc
 or
 .I @SYSCONFDIR@/colorit.conf
@@ -58,7 +60,7 @@ Specify a pager (- for none). The default is
 Specify a preprocessor (- for none).
 .SH "FILES"
 .TP
-.I ~/.coloritrc
+.I ~/.coloritrc\fR or \fI$XDG_CONFIG_HOME/coloritrc
 User's
 .B colorit
 configuration file

--- a/colorit/colorit.in
+++ b/colorit/colorit.in
@@ -28,7 +28,11 @@ colorit 0.0.1\n\
 
 pp='m4'
 
-config_file=$HOME/.coloritrc
+if [ -d "${XDG_CONFIG_HOME}" ]; then
+	config_file=${XDG_CONFIG_HOME}/coloritrc
+else
+	config_file=$HOME/.coloritrc
+fi
 
 while test $# -ne 0; do
     case $1 in


### PR DESCRIPTION
I am aware that there is the -c flag, which lets you specify a custom configuration file. However, I think that the colorit script should comply with the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) by default.