### PR TITLE
fix: build errors when building with GCC 14

### DIFF
--- a/dictd/dictd.c
+++ b/dictd/dictd.c
@@ -766,7 +766,7 @@ static int init_mime_db_list (const void *datum)
 static int init_plugin( const void *datum )
 {
 #ifdef USE_PLUGIN
-	dictDatabase *db = (dictDatabase *)datum;
+	const dictDatabase *db = (const dictDatabase *)datum;
 	dict_plugin_init(db);
 #endif
 
@@ -1001,7 +1001,7 @@ static int init_database_short (const void *datum)
 static int close_plugin(const void *datum)
 {
 #ifdef USE_PLUGIN
-	dictDatabase  *db = (dictDatabase *)datum;
+	const dictDatabase *db = (const dictDatabase *)datum;
 	dict_plugin_destroy (db);
 #endif
 

--- a/dictd/plugin.c
+++ b/dictd/plugin.c
@@ -16,6 +16,7 @@
  * 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#include "common.h"
 #include "dictd.h"
 #include "plugin.h"
 #include "strategy.h"
@@ -555,7 +556,7 @@ static dictPlugin *create_plugin (
 	return plugin;
 }
 
-int dict_plugin_init(dictDatabase *db)
+int dict_plugin_init(const dictDatabase *db)
 {
 	int ret = 0;
 	lst_List list;
@@ -604,7 +605,7 @@ int dict_plugin_init(dictDatabase *db)
 	return 0;
 }
 
-void dict_plugin_destroy ( dictDatabase *db )
+void dict_plugin_destroy (const dictDatabase *db )
 {
 	int ret;
 

--- a/dictd/plugin.h
+++ b/dictd/plugin.h
@@ -24,9 +24,9 @@
 #include "dictdplugin.h"
 
 /* initialize the plugin associated with db*/
-extern int dict_plugin_init (dictDatabase *db);
+extern int dict_plugin_init (const dictDatabase *db);
 /* destroy the plugin associated with db*/
-extern void dict_plugin_destroy (dictDatabase *db);
+extern void dict_plugin_destroy (const dictDatabase *db);
 
 /* search */
 extern int dict_search_plugin (

--- a/dictdplugins/dictdplugin_dbi/dictdplugin_dbi.c
+++ b/dictdplugins/dictdplugin_dbi/dictdplugin_dbi.c
@@ -27,6 +27,8 @@
 #include <dbi/dbi.h>
 
 #include <stdio.h>
+#include <string.h>
+#include <assert.h>
 
 #define BUFSIZE 4096
 


### PR DESCRIPTION
A lot of things got cleaned, but still I cannot avoid this error:

```
[   18s] cc -I/home/abuild/rpmbuild/BUILD/dictd-1.13.1+git.1714073710.c480a4c/libdictd -I/home/abuild/rpmbuild/BUILD/dictd-1.13.1+git.1714073710.c480a4c/libcommon -O2 -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -Werror=return-type -flto=auto -g -fPIC -DUSE_PLUGIN=1 -I/home/abuild/rpmbuild/BUILD/dictd-1.13.1+git.1714073710.c480a4c/dictdplugins/include -I/home/abuild/rpmbuild/BUILD/dictd-1.13.1+git.1714073710.c480a4c/libdictd  -I/home/abuild/rpmbuild/BUILD/dictd-1.13.1+git.1714073710.c480a4c/dictd -I/home/abuild/rpmbuild/BUILD/dictd-1.13.1+git.1714073710.c480a4c/libcommon  -D_DICT_VERSION=2.0.0 -D_DICT_CONFIG_PATH=/etc -D_DICT_PLUGIN_PATH=/usr/libexec -D_DICT_DICTIONARY_PATH=/usr/share -DHAVE_FUNC2_GETGROUPS_UNISTD_H=1 -D_GNU_SOURCE -D_GNU_SOURCE -D_MKC_CHECK_PROGNAME -D_MKC_CHECK_MACRO -D_MKC_CHECK_ERR -D_MKC_CHECK_STRLCPY -D_MKC_CHECK_STRLCAT -D_MKC_CHECK_STRNDUP -D_MKC_CHECK_REALLOCARR -D_MKC_CHECK_STRTOI -D_MKC_CHECK_STRTOU -D_MKC_CHECK_EFUN -DHAVE_VAR_PROGRAM_INVOCATION_SHORT_NAME_ERRNO_H=1 -DCUSTOM_ATTRIBUTE_NORETURN=1 -DCUSTOM_ATTRIBUTE_PURE=1 -DCUSTOM_ATTRIBUTE_PRINTFLIKE=1 -DCUSTOM_ATTRIBUTE_CONST=1 -DCUSTOM_ATTRIBUTE_ALWAYS_INLINE=1 -DCUSTOM_ATTRIBUTE_ALIGNED=1 -DHAVE_HEADER_ERR_H=1 -DHAVE_FUNC3_ERR_ERR_H=1 -DHAVE_FUNC3_ERRX_ERR_H=1 -DHAVE_PROTOTYPE_VERR=1 -DHAVE_PROTOTYPE_VERRX=1 -DHAVE_FUNC3_STRLCPY_STRING_H=1 -DHAVE_FUNC3_STRLCAT_STRING_H=1 -DHAVE_FUNC2_STRNDUP_STRING_H=1 -I/usr/share/mk-configure/features   -Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith -Wreturn-type -Wswitch -Wshadow -Wcast-qual -Wwrite-strings -Wno-unused-parameter    -Werror     -Wno-error=unused-function -Wno-error=unused-const-variable -Wno-error=format-truncation -erroff=E_STATEMENT_NOT_REACHED -Wno-error=deprecated-declarations -DMKC_ERR_IS_FINE   -c -o plugin.o -O2 -Wall -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=3 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -Werror=return-type -flto=auto -g -fPIC  plugin.c
[   18s] plugin.c: In function ‘dict_plugin_init’:
[   18s] plugin.c:598:30: error: assignment of member ‘plugin’ in read-only object
[   18s]   598 |                 db -> plugin = create_plugin (
[   18s]       |                              ^
[   18s] plugin.c: In function ‘dict_plugin_destroy’:
[   18s] plugin.c:631:22: error: assignment of member ‘plugin’ in read-only object
[   18s]   631 |         db -> plugin = NULL;
[   18s]       |                      ^
[   18s] *** Error code 1
[   18s] 
[   18s] Stop.
```

[Complete build log](https://github.com/user-attachments/files/17234349/_log.txt)


Fixes: https://github.com/cheusov/dictd/issues/21